### PR TITLE
Use raw pointer for Context and Device, mark them Send

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -5,11 +5,13 @@ use std::ffi::CStr;
 use std::os::raw::c_char;
 use std::ptr;
 
-pub struct Context<'a> {
-	pub(crate) ptr: &'a mut nfc_context,
+pub struct Context {
+	pub(crate) ptr: *mut nfc_context,
 }
 
-impl<'a> Context<'a> {
+unsafe impl Send for Context {}
+
+impl Context {
 	pub fn new() -> Result<Self> {
 		match unsafe {
 			let mut p: *mut nfc_context = ptr::null_mut();
@@ -40,7 +42,7 @@ impl<'a> Context<'a> {
 	}
 }
 
-impl<'a> Drop for Context<'a> {
+impl Drop for Context {
 	fn drop(&mut self) {
 		unsafe { nfc_exit(self.ptr); }
 	}

--- a/src/device.rs
+++ b/src/device.rs
@@ -63,12 +63,14 @@ use std::os::raw::{c_char, c_int, c_void};
 use std::ffi::CStr;
 use std::ptr;
 
-pub struct Device<'a> {
-	ptr: &'a mut nfc_device,
+pub struct Device {
+	ptr: *mut nfc_device,
 }
 
-impl<'a> Device<'a> {
-	fn new_device(context: &'a mut Context, connstring: Option<&str>) -> Result<Self> {
+unsafe impl Send for Device {}
+
+impl Device {
+	fn new_device(context: &mut Context, connstring: Option<&str>) -> Result<Self> {
 		let mut connstring_ptr = ptr::null_mut();
 		if let Some(connstring) = connstring {
 			let mut constring_fixed_size = ['\0' as c_char; 1024];
@@ -84,11 +86,11 @@ impl<'a> Device<'a> {
 		}
 	}
 
-	pub fn new(context: &'a mut Context) -> Result<Self> {
+	pub fn new(context: &mut Context) -> Result<Self> {
 		Self::new_device(context, None)
 	}
 
-	pub fn new_with_connstring(context: &'a mut Context, connstring: &str) -> Result<Self> {
+	pub fn new_with_connstring(context: &mut Context, connstring: &str) -> Result<Self> {
 		Self::new_device(context, Some(connstring))
 	}
 
@@ -391,7 +393,7 @@ impl<'a> Device<'a> {
 	}
 }
 
-impl<'a> Drop for Device<'a> {
+impl Drop for Device {
 	fn drop(&mut self) {
 		unsafe { nfc_close(self.ptr); }
 	}


### PR DESCRIPTION
The following code will not compile due to lifetime constraints:

```rust
use std::sync::{Arc, Mutex};
use std::thread;

pub(crate) struct NfcState<'a> {
    context: nfc1::Context<'a>,
}

pub(crate) struct Reader<'a> {
    pub(crate) name: String,
    device: Arc<Mutex<nfc1::Device<'a>>>,
}

impl NfcState<'_> {
    pub(crate) fn new() -> Result<Self, ()> {
        let context = nfc1::Context::new().unwrap();
        Ok(Self {
            context,
        })
    }

    pub(crate) fn open_reader(&mut self, name: &str, conn_string: &str) -> Result<Reader, ()> {
        let mut device = self.context.open_with_connstring(conn_string).expect("Failed to open NFC reader");
        device.initiator_init().expect("Failed to initialize NFC reader");

        Ok(Reader {
            name: name.to_string(),
            device: Arc::new(Mutex::new(device)),
        })
    }
}

impl Reader<'_> {
    pub(crate) fn begin_reading(&mut self) -> Result<(), ()> {
        let foo = self.device.clone();
        let join_handle = thread::spawn(move || {
            let mut bar = foo.lock().unwrap();
        });

        Ok(())
    }
}
```

```
error[E0521]: borrowed data escapes outside of method
  --> src/nfc.rs:34:19
   |
33 |     pub(crate) fn begin_reading(&mut self) -> Result<(), ()> {
   |                                 ---------
   |                                 |
   |                                 `self` is a reference that is only valid in the method body
   |                                 has type `&mut nfc::Reader<'1>`
34 |         let foo = self.device.clone();
   |                   ^^^^^^^^^^^^^^^^^^^
   |                   |
   |                   `self` escapes the method body here
   |                   argument requires that `'1` must outlive `'static`
   |
   = note: requirement occurs because of the type `std::sync::Mutex<Device<'_>>`, which makes the generic argument `Device<'_>` invariant
   = note: the struct `std::sync::Mutex<T>` is invariant over the parameter `T`
   = help: see <https://doc.rust-lang.org/nomicon/subtyping.html> for more information about variance
```

When the changes in this PR are applied, the code above may be reworked as follows:

```diff
--- example.rs	2024-11-06 18:43:07.180832094 -0500
+++ example-reworked.rs	2024-11-06 18:44:14.831005114 -0500
@@ -1,16 +1,16 @@
 use std::sync::{Arc, Mutex};
 use std::thread;
 
-pub(crate) struct NfcState<'a> {
-    context: nfc1::Context<'a>,
+pub(crate) struct NfcState {
+    context: nfc1::Context,
 }
 
-pub(crate) struct Reader<'a> {
+pub(crate) struct Reader {
     pub(crate) name: String,
-    device: Arc<Mutex<nfc1::Device<'a>>>,
+    device: Arc<Mutex<nfc1::Device>>,
 }
 
-impl NfcState<'_> {
+impl NfcState {
     pub(crate) fn new() -> Result<Self, ()> {
         let context = nfc1::Context::new().unwrap();
         Ok(Self {
@@ -29,7 +29,7 @@
     }
 }
 
-impl Reader<'_> {
+impl Reader {
     pub(crate) fn begin_reading(&mut self) -> Result<(), ()> {
         let foo = self.device.clone();
         let join_handle = thread::spawn(move || {
```